### PR TITLE
Update Bbdelay.ny

### DIFF
--- a/.gitbook/assets/Bbdelay.ny
+++ b/.gitbook/assets/Bbdelay.ny
@@ -1,5 +1,5 @@
 ;nyquist plug-in
-;version 
+;version 1
 ;type process
 ;name "Bouncing ball delay with panning..."
 ;action "Performing bouncing ball Delay with panning..."


### PR DESCRIPTION
Problem: plugin cannot be applied or previewed.
Fix: Add version number, as suggested by Steve.