### PR TITLE
Update plugin-suites.md to include Linux availability for MuseFX

### DIFF
--- a/realtime-effects/plugin-suites.md
+++ b/realtime-effects/plugin-suites.md
@@ -14,7 +14,7 @@ MuseFX is a free and expanding collection of high quality plugins for Audacity, 
 Download Muse hub
 {% endembed %}
 
-<figure><img src="../.gitbook/assets/image (10).png" alt=""><figcaption><p>MuseFX can be downloaded from the "Effects" tab in the Muse Hub</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (10).png" alt=""><figcaption><p>MuseFX can be downloaded from the "Effects" tab in the Muse Hub.</p><p>Check individual plugins for availablility on Linux Platforms.</p></figcaption></figure>
 
 ## Available for all platforms
 


### PR DESCRIPTION
Adds a message to indicate to Linux users that MuseFX plugins are available via author or external download.