### PR TITLE
docs: add LADSPA user plugin path on macOS

### DIFF
--- a/basics/customizing-audacity/installing-plugins.md
+++ b/basics/customizing-audacity/installing-plugins.md
@@ -42,6 +42,7 @@ All Plugins can be installed per-user (`~/Library/Audio/Plug-Ins/...`) or system
 * LV2: `~/.lv2` or `/Library/Audio/Plug-Ins/LV2`,\
   **Note:** always copy the entire .lv2 _folder_
 * Vamp: `/Library/Audio/Plug-Ins/Vamp`
+* LADSPA: `~/Library/Application Support/audacity/Plug-Ins/`
 * Nyquist: See below
 {% endtab %}
 


### PR DESCRIPTION
Refs #45

Adds `~/Library/Application Support/audacity/Plug-Ins/` to the macOS tab as the LADSPA user plugin path, matching the existing Windows entry for `%AppData%\audacity\Plug-ins`.

Verified against the Audacity 3.x source: `LadspaEffectsModule.cpp` loads from `FileNames::PlugInDir()`, which resolves to this path on macOS. VST/VST3/AU/LV2/Vamp don't use `PlugInDir()`, so the entry is correctly LADSPA-only. Folder also confirmed on my own Mac.

Scoped to macOS — Linux paths from audacity/audacity#5746 left for a follow-up.