### PR TITLE
docs: add user-accessible plugin directories for all OS

### DIFF
--- a/basics/customizing-audacity/installing-plugins.md
+++ b/basics/customizing-audacity/installing-plugins.md
@@ -3,7 +3,7 @@
 You can download various plugins here:
 
 {% content-ref url="https://app.gitbook.com/o/-MhmG2mhIIHTtQPuHV_k/s/klCVENFte0GRy5IqVz0W/" %}
-[Audacity Plugins](https://app.gitbook.com/o/-MhmG2mhIIHTtQPuHV\_k/s/klCVENFte0GRy5IqVz0W/)
+[Audacity Plugins](https://app.gitbook.com/o/-MhmG2mhIIHTtQPuHV_k/s/klCVENFte0GRy5IqVz0W/)
 {% endcontent-ref %}
 
 Most plugins get automatically activated once you install them on your system.
@@ -11,10 +11,10 @@ Most plugins get automatically activated once you install them on your system.
 {% hint style="warning" %}
 **Caution:**
 
-* 64-bit Audacity can only run 64-bit plugins, and 32-bit Audacity can only run 32-bit plugins.
-* Additionally, Apple Silicon (arm64) Audacity cannot run Intel (x86-64) plugins and vice versa.
-* "Instrument" versions of plugins (VSTi, LV2i) are not supported.
-{% endhint %}
+- 64-bit Audacity can only run 64-bit plugins, and 32-bit Audacity can only run 32-bit plugins.
+- Additionally, Apple Silicon (arm64) Audacity cannot run Intel (x86-64) plugins and vice versa.
+- "Instrument" versions of plugins (VSTi, LV2i) are not supported.
+  {% endhint %}
 
 ## Manually installing plugins
 
@@ -24,38 +24,44 @@ If a plugin doesn't get found by Audacity, or doesn't come with an installer, mo
 {% tab title="Windows" %}
 You can access the Common Files folder quickly by hitting `🪟 WINDOWS key + R` to launch Run and typing `%ProgramFiles%\Common Files`
 
-* VST2: `C:\Program Files\Common Files\VST2` or `C:\Program Files\Steinberg\VSTPlugins`
-* VST3: `C:\Program Files\Common Files\VST3`
-* LV2: `C:\Program Files\Common Files\LV2`\
+- VST2: `C:\Program Files\Common Files\VST2` or `C:\Program Files\Steinberg\VSTPlugins`
+- VST3: `C:\Program Files\Common Files\VST3`
+- LV2: `C:\Program Files\Common Files\LV2`\
   **Note:** Always copy the complete .lv2 _folder_
-* LADSPA: `C:\Users\<username>\Appdata\Roaming\audacity\Plug-ins\` **Note:** You can quickly access this folder by hitting `🪟 WINDOWS key + R` to launch Run and typing `%AppData%\audacity\Plug-ins`
-* Vamp: `C:\Program Files\Vamp Plugins\`
-* Nyquist: See below
-{% endtab %}
+- LADSPA and other user-installed plugin formats such as VST3: `C:\Users\<username>\AppData\Roaming\audacity\Plug-Ins\`
+  **Note:** This per-user Audacity folder can hold LADSPA and compatible plugin files and does not require administrator privileges. You can quickly access it by hitting `🪟 WINDOWS key + R` to launch Run and typing `%AppData%\audacity\Plug-Ins`
+- Vamp: `C:\Program Files\Vamp Plugins\`
+- Nyquist: See below
+  {% endtab %}
 
 {% tab title="macOS" %}
-All Plugins can be installed per-user (`~/Library/Audio/Plug-Ins/...`) or system-wide (`/Library/Audio/Plug-Ins/...`). In following, only the system-wide path is named
+All Plugins can be installed per-user (`~/Library/Audio/Plug-Ins/...`) or system-wide (`/Library/Audio/Plug-Ins/...`). In following, only the system-wide path is named.
 
-* Audio Unit: `/Library/Audio/Plug-Ins/Components/`
-* VST2: `/Library/Audio/Plug-Ins/VST/`
-* VST3: `/Library/Audio/Plug-Ins/VST3/`
-* LV2: `~/.lv2` or `/Library/Audio/Plug-Ins/LV2`,\
+**Note:** The per-user directories under `~/Library/Audio/Plug-Ins/` and `~/.lv2` are accessible without administrator privileges.
+
+- Audio Unit: `/Library/Audio/Plug-Ins/Components/`
+- VST2: `/Library/Audio/Plug-Ins/VST/`
+- VST3: `/Library/Audio/Plug-Ins/VST3/`
+- LV2: `~/.lv2` or `/Library/Audio/Plug-Ins/LV2`,\
   **Note:** always copy the entire .lv2 _folder_
-* Vamp: `/Library/Audio/Plug-Ins/Vamp`
-* Nyquist: See below
-{% endtab %}
+- Vamp: `/Library/Audio/Plug-Ins/Vamp`
+- Nyquist: See below
+  {% endtab %}
 
 {% tab title="Linux" %}
-* LV2: `~/.lv2`, `/usr/local/lib/lv2` (for 32-bit) or `/usr/local/lib64/lv2` (for 64-bit)\
+
+**Note:** The following `~`-based directories are per-user and do not require administrator privileges.
+
+- LV2: `~/.lv2`, `/usr/local/lib/lv2` (for 32-bit) or `/usr/local/lib64/lv2` (for 64-bit)\
   **Note**: Always copy the entire .lv2 _folder_
-* VST2: `~/.vst` or `/usr/local/lib/vst`\
+- VST2: `~/.vst` or `/usr/local/lib/vst`\
   **Note**: Many VST effects are Windows-only
-* VST3: `~/.vst3` or `/usr/local/lib/vst3`
-* LADSPA: `~/.ladspa` or `/usr/local/lib/ladspa`
-* Vamp: `~/.vamp` or `/usr/local/lib/vamp`
-* Nyquist: See below
-{% endtab %}
-{% endtabs %}
+- VST3: `~/.vst3` or `/usr/local/lib/vst3`
+- LADSPA: `~/.ladspa` or `/usr/local/lib/ladspa`
+- Vamp: `~/.vamp` or `/usr/local/lib/vamp`
+- Nyquist: See below
+  {% endtab %}
+  {% endtabs %}
 
 ## Installing Nyquist plugins
 


### PR DESCRIPTION
Closes #45

Adds documentation for user-accessible plugin directories on Windows, 
macOS and Linux that do not require administrator privileges.

Changes made:
- Windows: added %AppData%\audacity\Plug-Ins as a per-user directory 
  that supports LADSPA and other formats such as VST3, without requiring 
  admin privileges.
- macOS: added ~/Library/Audio/Plug-Ins/ per-user directories and 
  clarified they are accessible without admin privileges.
- Linux: clarified that all ~-based directories are per-user and do not 
  require admin privileges.