### PR TITLE
docs: clarify VST2 is not supported in Audacity 4

### DIFF
--- a/basics/customizing-audacity/installing-plugins.md
+++ b/basics/customizing-audacity/installing-plugins.md
@@ -3,7 +3,7 @@
 You can download various plugins here:
 
 {% content-ref url="https://app.gitbook.com/o/-MhmG2mhIIHTtQPuHV_k/s/klCVENFte0GRy5IqVz0W/" %}
-[Audacity Plugins](https://app.gitbook.com/o/-MhmG2mhIIHTtQPuHV\_k/s/klCVENFte0GRy5IqVz0W/)
+[Audacity Plugins](https://app.gitbook.com/o/-MhmG2mhIIHTtQPuHV_k/s/klCVENFte0GRy5IqVz0W/)
 {% endcontent-ref %}
 
 Most plugins get automatically activated once you install them on your system.
@@ -11,10 +11,11 @@ Most plugins get automatically activated once you install them on your system.
 {% hint style="warning" %}
 **Caution:**
 
-* 64-bit Audacity can only run 64-bit plugins, and 32-bit Audacity can only run 32-bit plugins.
-* Additionally, Apple Silicon (arm64) Audacity cannot run Intel (x86-64) plugins and vice versa.
-* "Instrument" versions of plugins (VSTi, LV2i) are not supported.
-{% endhint %}
+- 64-bit Audacity can only run 64-bit plugins, and 32-bit Audacity can only run 32-bit plugins.
+- Additionally, Apple Silicon (arm64) Audacity cannot run Intel (x86-64) plugins and vice versa.
+- "Instrument" versions of plugins (VSTi, LV2i) are not supported.
+- VST2 is not supported in AU4.
+  {% endhint %}
 
 ## Manually installing plugins
 
@@ -24,38 +25,38 @@ If a plugin doesn't get found by Audacity, or doesn't come with an installer, mo
 {% tab title="Windows" %}
 You can access the Common Files folder quickly by hitting `🪟 WINDOWS key + R` to launch Run and typing `%ProgramFiles%\Common Files`
 
-* VST2: `C:\Program Files\Common Files\VST2` or `C:\Program Files\Steinberg\VSTPlugins`
-* VST3: `C:\Program Files\Common Files\VST3`
-* LV2: `C:\Program Files\Common Files\LV2`\
+- VST3: `C:\Program Files\Common Files\VST3`
+- LV2: `C:\Program Files\Common Files\LV2`\
   **Note:** Always copy the complete .lv2 _folder_
-* LADSPA: `C:\Users\<username>\Appdata\Roaming\audacity\Plug-ins\` **Note:** You can quickly access this folder by hitting `🪟 WINDOWS key + R` to launch Run and typing `%AppData%\audacity\Plug-ins`
-* Vamp: `C:\Program Files\Vamp Plugins\`
-* Nyquist: See below
-{% endtab %}
+- LADSPA: `C:\Users\<username>\AppData\Roaming\audacity\Plug-ins\`\
+  **Note:** You can quickly access this folder by hitting `🪟 WINDOWS key + R` to launch Run and typing `%AppData%\audacity\Plug-ins`
+- Vamp: `C:\Program Files\Vamp Plugins\`
+- Nyquist: See below
+  {% endtab %}
 
 {% tab title="macOS" %}
 All Plugins can be installed per-user (`~/Library/Audio/Plug-Ins/...`) or system-wide (`/Library/Audio/Plug-Ins/...`). In following, only the system-wide path is named
 
-* Audio Unit: `/Library/Audio/Plug-Ins/Components/`
-* VST2: `/Library/Audio/Plug-Ins/VST/`
-* VST3: `/Library/Audio/Plug-Ins/VST3/`
-* LV2: `~/.lv2` or `/Library/Audio/Plug-Ins/LV2`,\
+- Audio Unit: `/Library/Audio/Plug-Ins/Components/`
+
+- VST3: `/Library/Audio/Plug-Ins/VST3/`
+- LV2: `~/.lv2` or `/Library/Audio/Plug-Ins/LV2`,\
   **Note:** always copy the entire .lv2 _folder_
-* Vamp: `/Library/Audio/Plug-Ins/Vamp`
-* Nyquist: See below
-{% endtab %}
+- Vamp: `/Library/Audio/Plug-Ins/Vamp`
+- Nyquist: See below
+  {% endtab %}
 
 {% tab title="Linux" %}
-* LV2: `~/.lv2`, `/usr/local/lib/lv2` (for 32-bit) or `/usr/local/lib64/lv2` (for 64-bit)\
+
+- LV2: `~/.lv2`, `/usr/local/lib/lv2` (for 32-bit) or `/usr/local/lib64/lv2` (for 64-bit)\
   **Note**: Always copy the entire .lv2 _folder_
-* VST2: `~/.vst` or `/usr/local/lib/vst`\
-  **Note**: Many VST effects are Windows-only
-* VST3: `~/.vst3` or `/usr/local/lib/vst3`
-* LADSPA: `~/.ladspa` or `/usr/local/lib/ladspa`
-* Vamp: `~/.vamp` or `/usr/local/lib/vamp`
-* Nyquist: See below
-{% endtab %}
-{% endtabs %}
+
+- VST3: `~/.vst3` or `/usr/local/lib/vst3`
+- LADSPA: `~/.ladspa` or `/usr/local/lib/ladspa`
+- Vamp: `~/.vamp` or `/usr/local/lib/vamp`
+- Nyquist: See below
+  {% endtab %}
+  {% endtabs %}
 
 ## Installing Nyquist plugins
 


### PR DESCRIPTION
Closes #102

Removed VST2 references from plugin installation paths and added a 
caution note clarifying that VST2 is not supported in Audacity 4.